### PR TITLE
Rover modifications to 1.8.4

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -155,7 +155,10 @@ resource "aws_iam_role_policy" "master_policy" {
         "s3:ListBucket",
         "s3:PutObject"
       ],
-      "Resource": "arn:aws:s3:::*",
+      "Resource": [
+        "arn:aws:s3:::${var.s3_bucket}/*",
+        "arn:aws:s3:::${var.s3_bucket}"
+      ],
       "Effect": "Allow"
     },
     {

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -138,3 +138,7 @@ variable "ign_rm_assets_service_id" {
 variable "ign_rm_assets_path_unit_id" {
   type = "string"
 }
+
+variable "s3_bucket" {
+  type = "string"
+}

--- a/modules/aws/worker-asg/ignition.tf
+++ b/modules/aws/worker-asg/ignition.tf
@@ -4,6 +4,7 @@ data "ignition_config" "main" {
     "${var.ign_installer_runtime_mappings_id}",
     "${var.ign_max_user_watches_id}",
     "${var.ign_s3_puller_id}",
+    "${data.ignition_file.resolved_conf_dropin.id}",
   ]
 
   systemd = [
@@ -12,4 +13,21 @@ data "ignition_config" "main" {
     "${var.ign_kubelet_service_id}",
     "${var.ign_locksmithd_service_id}",
   ]
+}
+
+data "aws_region" "current" {
+  current = true
+}
+
+data "ignition_file" "resolved_conf_dropin" {
+  filesystem = "root"
+  path       = "/etc/systemd/resolved.conf.d/10-resolved-conf.conf"
+  mode       = 0644
+
+  content {
+    content = <<EOF
+[Resolve]
+Domains=${data.aws_region.current.name == "us-east-1" ? "ec2.internal" : "${data.aws_region.current.name}.compute.internal"}
+EOF
+  }
 }

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -82,3 +82,7 @@ variable "worker_iam_role" {
 variable "ign_s3_puller_id" {
   type = "string"
 }
+
+variable "s3_bucket" {
+  type = "string"
+}

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -166,7 +166,7 @@ resource "aws_iam_role_policy" "worker_policy" {
       "Action" : [
         "s3:GetObject"
       ],
-      "Resource": "arn:aws:s3:::*",
+      "Resource": "arn:aws:s3:::${var.s3_bucket}/*",
       "Effect": "Allow"
     },
     {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region  = "${var.tectonic_aws_region}"
   profile = "${var.tectonic_aws_profile}"
-  version = "1.1.0"
+  version = "1.7.0"
 }
 
 data "aws_availability_zones" "azs" {}

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -149,6 +149,7 @@ module "masters" {
   root_volume_type                  = "${var.tectonic_aws_master_root_volume_type}"
   ssh_key                           = "${var.tectonic_aws_ssh_key}"
   subnet_ids                        = "${module.vpc.master_subnet_ids}"
+  s3_bucket                         = "${aws_s3_bucket.tectonic.bucket}"
 }
 
 module "ignition_workers" {
@@ -195,6 +196,7 @@ module "workers" {
   subnet_ids                        = "${module.vpc.worker_subnet_ids}"
   vpc_id                            = "${module.vpc.vpc_id}"
   worker_iam_role                   = "${var.tectonic_aws_worker_iam_role_name}"
+  s3_bucket                         = "${aws_s3_bucket.tectonic.bucket}"
 }
 
 module "dns" {


### PR DESCRIPTION
This manually adds default aws dns for the appropriate region to the search path.