### PR TITLE
[OPS-2922] Run dd-agent with an etcd check on the etcd nodes

### DIFF
--- a/modules/aws/etcd/ignition.tf
+++ b/modules/aws/etcd/ignition.tf
@@ -11,6 +11,11 @@ data "ignition_config" "etcd" {
     "${data.ignition_file.node_hostname.*.id[count.index]}",
     "${data.ignition_file.etcd_tls_zip.id}",
   ]
+
+  append {
+    source       = "${format("s3://%s/%s", var.s3_bucket, aws_s3_bucket_object.ignition_etcd_rover.key)}"
+    verification = "sha512-${sha512(data.ignition_config.rover.rendered)}"
+  }
 }
 
 data "ignition_file" "node_hostname" {

--- a/modules/aws/etcd/ignition_s3.tf
+++ b/modules/aws/etcd/ignition_s3.tf
@@ -1,0 +1,83 @@
+resource "aws_s3_bucket_object" "ignition_etcd_rover" {
+  bucket  = "${var.s3_bucket}"
+  key     = "ignition_etcd_rover.json"
+  content = "${data.ignition_config.rover.rendered}"
+  acl     = "private"
+
+  server_side_encryption = "AES256"
+
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}-ignition-rover",
+      "KubernetesCluster", "${var.cluster_name}",
+      "tectonicClusterID", "${var.cluster_id}"
+    ), var.extra_tags)}"
+}
+
+data "ignition_file" "dd_agent_confd_etcd" {
+  path       = "/home/core/etcd.yaml"
+  mode       = 0644
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = <<EOF
+init_config:
+instances:
+  - url: "https://localhost:2379"
+    ssl_keyfile: /etc/ssl/etcd/client.key
+    ssl_certfile: /etc/ssl/etcd/client.crt
+    ssl_cert_validation: false
+    ssl_ca_certs: /etc/ssl/etcd/ca.crt
+EOF
+  }
+}
+
+data "aws_ssm_parameter" "datadog_api_key" {
+  name = "datadog_api_key"
+}
+
+data "ignition_systemd_unit" "dd_agent" {
+  name    = "dd-agent.service"
+  enabled = true
+
+  content = <<EOF
+[Unit]
+Description=Datadog Agent
+Requires=docker.service
+After=docker.service
+[Service]
+Restart=always
+ExecStartPre=-/usr/bin/docker stop dd-agent
+ExecStartPre=-/usr/bin/docker rm -f dd-agent
+ExecStartPre=/usr/bin/docker pull datadog/docker-dd-agent
+TimeoutStartSec=0
+ExecStartPre=-/usr/bin/docker kill dd-agent
+ExecStartPre=-/usr/bin/docker rm dd-agent
+ExecStart=/bin/bash -c " \
+  docker run --name dd-agent \
+    -h %H \
+    --network=\"host\" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /proc/:/host/proc:ro \
+    -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+    -v /etc/ssl/etcd:/etc/ssl/etcd:ro \
+    -v /home/core/etcd.yaml:/conf.d/etcd.yaml:ro \
+    -e API_KEY=\"${data.aws_ssm_parameter.datadog_api_key.value}\" \
+    -e TAGS=\"tectonic-cluster:${var.cluster_name}\" \
+    datadog/docker-dd-agent"
+ExecStop=/usr/bin/docker stop dd-agent
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+data "ignition_config" "rover" {
+  systemd = [
+    "${data.ignition_systemd_unit.dd_agent.id}",
+  ]
+
+  files = [
+    "${data.ignition_file.dd_agent_confd_etcd.id}",
+  ]
+}

--- a/modules/aws/etcd/ignition_s3.tf
+++ b/modules/aws/etcd/ignition_s3.tf
@@ -38,8 +38,8 @@ data "aws_ssm_parameter" "datadog_api_key" {
 }
 
 data "ignition_systemd_unit" "dd_agent" {
-  name    = "dd-agent.service"
-  enabled = true
+  name   = "dd-agent.service"
+  enable = true
 
   content = <<EOF
 [Unit]

--- a/modules/aws/etcd/variables.tf
+++ b/modules/aws/etcd/variables.tf
@@ -80,3 +80,7 @@ variable "tls_zip" {
 variable "ign_etcd_dropin_id_list" {
   type = "list"
 }
+
+variable "s3_bucket" {
+  type = "string"
+}

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -84,6 +84,7 @@ module "etcd" {
   tls_enabled             = "${var.tectonic_etcd_tls_enabled}"
   tls_zip                 = "${module.etcd_certs.etcd_tls_zip}"
   ign_etcd_dropin_id_list = "${module.ignition_masters.etcd_dropin_id_list}"
+  s3_bucket               = "${aws_s3_bucket.tectonic.bucket}"
 }
 
 module "ignition_masters" {


### PR DESCRIPTION
Enable dd-agent and the etcd check on the etcd nodes.